### PR TITLE
change for invalid UserID

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -11,6 +11,7 @@ type UserRepository interface {
 	AddUser(ctx context.Context, user domain.User) (int64, error)
 	GetUser(ctx context.Context, id int64) (domain.User, error)
 	UpdateBalance(ctx context.Context, id int64, balance int64) error
+	GetMaxUserID(ctx context.Context) (int64, error)
 }
 
 type UserDBRepository struct {
@@ -45,6 +46,13 @@ func (r *UserDBRepository) UpdateBalance(ctx context.Context, id int64, balance 
 		return err
 	}
 	return nil
+}
+
+func (r *UserDBRepository) GetMaxUserID(ctx context.Context) (int64, error) {
+	row := r.QueryRowContext(ctx, "SELECT MAX(id) FROM users")
+
+	var id int64
+	return id, row.Scan(&id)
 }
 
 type ItemRepository interface {

--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -166,6 +166,17 @@ func (h *Handler) Login(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err)
 	}
 
+	//get the maximum value of the existing UserIDs
+	max_id,err:=h.UserRepo.GetMaxUserID(ctx)
+	if err != nil {
+		return echo.NewHTTPError(http.StatusInternalServerError,err)
+	}
+
+	//validation (whether userid is existing)
+	if req.UserID<1||req.UserID>max_id{
+		return echo.NewHTTPError(http.StatusBadRequest,"UserID is invalid")
+	}
+
 	//validation (whether password is empty)
 	if req.Password == ""{
 		return echo.NewHTTPError(http.StatusBadRequest,"Password cannot be empty")


### PR DESCRIPTION
change for TODO in handler.go 162-163
ログイン時に存在しないUserIDを入力した際のエラー処理を追加しました。I've added error handling for instances where a non-existent UserID is entered during login.
具体的には1未満または存在する最大のIDより大きいときにエラーが出ます。An error will occur if the ID is less than 1 or greater than the existing maximum ID
最大のIDを取得するために、backend/db/repository.goに関数を追加しました。For getting the maximum UserID , I've added a function to backend/db/repository.go .

これでログイン時のvalidationはpasswordが空かどうか、idが存在するかどうかの二つになりました。その他にも文字数オーバーや使用できない文字等で処理を行うことが多いと教えていただいたので、案をお願いします:)