### PR TITLE
purchase checked

### DIFF
--- a/backend/db/repository.go
+++ b/backend/db/repository.go
@@ -65,6 +65,7 @@ type ItemRepository interface {
 	GetCategory(ctx context.Context, id int64) (domain.Category, error)
 	GetCategories(ctx context.Context) ([]domain.Category, error)
 	UpdateItemStatus(ctx context.Context, id int32, status domain.ItemStatus) error
+	GetItemStatus(ctx context.Context, id int32) (domain.ItemStatus, error)
 }
 
 type ItemDBRepository struct {
@@ -98,6 +99,7 @@ func (r *ItemDBRepository) AddCategory(ctx context.Context, categoryName domain.
 	var res domain.Category
 	return res, row.Scan(&res.ID, &res.Name)
 }
+
 
 func (r *ItemDBRepository) GetItem(ctx context.Context, id int32) (domain.Item, error) {
 	row := r.QueryRowContext(ctx, "SELECT * FROM items WHERE id = ?", id)
@@ -159,6 +161,13 @@ func (r *ItemDBRepository) UpdateItemStatus(ctx context.Context, id int32, statu
 		return err
 	}
 	return nil
+}
+
+func (r *ItemDBRepository) GetItemStatus(ctx context.Context, id int32) (domain.ItemStatus, error) {
+	row := r.QueryRowContext(ctx, "SELECT status FROM items WHERE id = ?", id)
+	
+	var status domain.ItemStatus
+	return status, row.Scan(&status)
 }
 
 func (r *ItemDBRepository) GetCategory(ctx context.Context, id int64) (domain.Category, error) {


### PR DESCRIPTION
Purchase箇所のtodoを直しました．
・TODO: overflow：itemIDのoverflow対策　
```
itemID, err := strconv.Atoi(c.Param("itemID"))
↓
itemID, err := strconv.ParseInt(c.Param("itemID"), 10, 64)
```
ParseIntの場合，overflowになったらエラーがでるため対処できるみたいです．（おそらく）

・TODO: if it is fail here, item status is still sold
エラーで処理落ちしても，購入された仕様になっていたため，購入されたかのステータス処理を一番最後にしました．

・TODO: update only when item status is on sale
商品のステータスが売り切れだった場合，購入できないようにしました．
```
	// status change
	status,err := h.ItemRepo.GetItemStatus(ctx, int32(itemID));// get now status
	if status == domain.ItemStatusOnSale {
		if err := h.ItemRepo.UpdateItemStatus(ctx, int32(itemID), domain.ItemStatusSoldOut); err != nil {
			return echo.NewHTTPError(http.StatusInternalServerError, err)
		}
	}else{
		// TODO: update only when item status is on sale <- checked
		// http.StatusPreconditionFailed(412) <- checked
		return echo.NewHTTPError(http.StatusPreconditionFailed,"item status is soldout")
		
	}

```
・TODO: balance consistency
これはいまいち実現できたか分からないですが…
残金を処理をする時に，購入者の処理が成功して，販売者の処理が失敗した場合．購入者へお金を返金するようにしました．
```
	if err := h.UserRepo.UpdateBalance(ctx, userID, user.Balance-item.Price); err != nil {
		return echo.NewHTTPError(http.StatusInternalServerError, err)
	}

	if err := h.UserRepo.UpdateBalance(ctx, sellerID, seller.Balance+item.Price); err != nil {
		h.UserRepo.UpdateBalance(ctx, userID, user.Balance+item.Price)
		return echo.NewHTTPError(http.StatusInternalServerError, err)
	}

```
・TODO: not to buy own items.
自分の商品を購入できないようにしました．sellerID == userIDの時にエラーが出ます．
今後開発するときに不便かもしれないです…複数ウィンドウを開いて操作するのがいいかと思います．
```
sellerID := item.UserID
if sellerID == userID{
return echo.NewHTTPError(http.StatusPreconditionFailed, "not to buy own items")
}
```
![image](https://github.com/Airi-hub/mercari-build-hackathon-2023/assets/49065829/004cbe10-764a-4977-bcb1-0fd287ed5507)
