### PR TITLE
chenge helper.ts to display error message

### DIFF
--- a/frontend/simple-mercari-web/src/helper.ts
+++ b/frontend/simple-mercari-web/src/helper.ts
@@ -8,14 +8,24 @@ const wrap = <T>(task: Promise<Response>): Promise<T> => {
           response
             .json()
             .then((json) => {
-              // jsonが取得できた場合だけresolve
               resolve(json);
             })
             .catch((error) => {
               reject(error);
             });
         } else {
-          reject(response);
+          response
+            .json()
+            .then((json) => {
+              // If the response includes a 'message' field, reject with that message.
+              // Otherwise, reject with the entire response.
+              const errorMessage = json.message || response;
+              reject(new Error(errorMessage));
+            })
+            .catch((error) => {
+              // If the response couldn't be parsed as JSON, reject with the whole response.
+              reject(error);
+            });
         }
       })
       .catch((error) => {
@@ -23,7 +33,6 @@ const wrap = <T>(task: Promise<Response>): Promise<T> => {
       });
   });
 };
-
 const wrapBlob = (task: Promise<Response>): Promise<Blob> => {
   return new Promise((resolve, reject) => {
     task


### PR DESCRIPTION
エラーメッセージをブラウザで表示させるためにhelper.tsを変更しました。
具体的には、今までHTTPレスポンスコード400を受け取った際にはsuccessとして扱うものをerrorとして扱うよう再定義しました。基本的にここ以外のコードを変更する必要はなかったので現時点で問題はないのですが、完全に整合性が取れているかの確認はしていないので、問題が起きたら知らせてください。
backendでのエラーハンドリング時に定義したエラーメッセージそのままなので、より分かりやすい記述にする必要があるかもしれません