### PR TITLE
display password-is-incollect and invalid-balance

### DIFF
--- a/backend/handler/handler.go
+++ b/backend/handler/handler.go
@@ -254,7 +254,7 @@ func (h *Handler) Login(c echo.Context) error {
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(req.Password)); err != nil {
 		if err == bcrypt.ErrMismatchedHashAndPassword {
-			return echo.NewHTTPError(http.StatusUnauthorized, err)
+			return echo.NewHTTPError(http.StatusUnauthorized, "The password is incollect")
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
@@ -797,7 +797,7 @@ func (h *Handler) PutItem(c echo.Context) error {
 func (h *Handler) GetCategoryItem(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	categoryID,_ := strconv.ParseInt(c.Param("categoryID"), 10, 64)
+	categoryID, _ := strconv.ParseInt(c.Param("categoryID"), 10, 64)
 
 	items, err := h.ItemRepo.GetItemByCategory(ctx, categoryID)
 

--- a/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
+++ b/frontend/simple-mercari-web/src/components/UserProfile/UserProfile.tsx
@@ -31,7 +31,7 @@ export const UserProfile: React.FC = () => {
     const res = await fetcher(`/balance`, getPostParams({
         balance: addedbalance,
       }, cookies.token)).catch(handlePostError)
-    window.location.reload()
+    if(res)window.location.reload()
   };
 
   return (


### PR DESCRIPTION
パスワードが違うときの適切なエラーメッセージの表示
不正な残高を入力したときにページを更新せずエラーメッセージを表示
上記二点の修正